### PR TITLE
Switch from wikimedia/ip-set to wikimedia/ip-utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "wikimedia/ip-set": "^1.2",
+    "wikimedia/ip-utils": "^4.0.1 || ^5.0",
     "yireo/magento2-salesblock2": "^2.2",
     "ext-pcre": "*"
   },


### PR DESCRIPTION
See also: [wikimedia/ip-utils](https://packagist.org/packages/wikimedia/ip-utils) and [wikimedia/ip-set](https://packagist.org/packages/wikimedia/ip-set) on Packagist.

* wikimedia/ip-set 1.x renames IPSet to Wikimedia/IPSet and keeps an IPSet alias. This repo already uses Wikimedia/IPSet.
* wikimedia/ip-set 2.0 removes the old IPSet alias.
* wikimedia/ip-utils 4.0 depends on wikimedia/ip-set (2.0, 3.0, or 4.0; which are interchangable and vary only in required PHP version which is auto-selected by Composer).
* wikimedia/ip-utils 5.0 bundles Wikimedia/IPSet and requires PHP 7.4+. The wikimedia/ip-set package is now deprecated.

